### PR TITLE
Add first quality toolchains and github workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,50 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# TS/JS-Files
+[*.{ts,js}]
+indent_size = 2
+
+# JSON-Files
+[*.json]
+indent_style = tab
+
+# ReST-Files
+[*.{rst,rst.txt}]
+indent_size = 4
+max_line_length = 80
+
+# Markdown-Files
+[*.md]
+max_line_length = 80
+
+[*.{neon,json,yaml}]
+indent_size = 2
+
+# TypoScript
+[*.{typoscript,tsconfig}]
+indent_size = 2
+
+# XLF-Files
+[*.xlf]
+indent_style = tab
+
+# SQL-Files
+[*.sql]
+indent_style = tab
+indent_size = 2
+
+# .htaccess
+[{_.htaccess,.htaccess}]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,10 +16,6 @@ trim_trailing_whitespace = true
 [*.{ts,js}]
 indent_size = 2
 
-# JSON-Files
-[*.json]
-indent_style = tab
-
 # ReST-Files
 [*.{rst,rst.txt}]
 indent_size = 4
@@ -29,8 +25,11 @@ max_line_length = 80
 [*.md]
 max_line_length = 80
 
-[*.{neon,json,yaml}]
+[*.{neon,json,yaml,yml}]
 indent_size = 2
+
+[composer.json]
+indent_size = 4
 
 # TypoScript
 [*.{typoscript,tsconfig}]

--- a/.github/workflows/testcore10.yml
+++ b/.github/workflows/testcore10.yml
@@ -1,0 +1,28 @@
+name: tests core 10
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '56 4 * * *'
+
+jobs:
+  testsuite:
+    name: all tests with core 10
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php: [ '7.2', '7.3', '7.4' ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install testing system
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t 10 -s composerUpdate
+
+      - name: Lint PHP
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
+
+      - name: CGL
+        if: ${{ matrix.php <= '8.1' }}
+        run: Build/Scripts/runTests.sh -n -p ${{ matrix.php }} -s cgl

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+
+#
+# TYPO3 core test runner based on docker and docker-compose.
+#
+
+# Function to write a .env file in Build/testing-docker
+# This is read by docker-compose and vars defined here are
+# used in Build/testing-docker/docker-compose.yml
+setUpDockerComposeDotEnv() {
+    # Delete possibly existing local .env file if exists
+    [ -e .env ] && rm .env
+    # Set up a new .env file for docker-compose
+    {
+        echo "COMPOSE_PROJECT_NAME=local"
+        # To prevent access rights of files created by the testing, the docker image later
+        # runs with the same user that is currently executing the script. docker-compose can't
+        # use $UID directly itself since it is a shell variable and not an env variable, so
+        # we have to set it explicitly here.
+        echo "HOST_UID=`id -u`"
+        # Your local user
+        echo "ROOT_DIR=${ROOT_DIR}"
+        echo "HOST_USER=${USER}"
+        echo "TEST_FILE=${TEST_FILE}"
+        echo "TYPO3_VERSION=${TYPO3_VERSION}"
+        echo "PHP_XDEBUG_ON=${PHP_XDEBUG_ON}"
+        echo "DOCKER_PHP_IMAGE=${DOCKER_PHP_IMAGE}"
+        echo "EXTRA_TEST_OPTIONS=${EXTRA_TEST_OPTIONS}"
+        echo "SCRIPT_VERBOSE=${SCRIPT_VERBOSE}"
+        echo "CGLCHECK_DRY_RUN=${CGLCHECK_DRY_RUN}"
+        echo "DATABASE_DRIVER=${DATABASE_DRIVER}"
+    } > .env
+}
+
+# Options -a and -d depend on each other. The function
+# validates input combinations and sets defaults.
+handleDbmsAndDriverOptions() {
+    case ${DBMS} in
+        mysql|mariadb)
+            [ -z "${DATABASE_DRIVER}" ] && DATABASE_DRIVER="mysqli"
+            if [ "${DATABASE_DRIVER}" != "mysqli" ] && [ "${DATABASE_DRIVER}" != "pdo_mysql" ]; then
+                echo "Invalid option -a ${DATABASE_DRIVER} with -d ${DBMS}" >&2
+                echo >&2
+                echo "call \"./Build/Scripts/runTests.sh -h\" to display help and valid options" >&2
+                exit 1
+            fi
+            ;;
+        postgres|sqlite)
+            if [ -n "${DATABASE_DRIVER}" ]; then
+                echo "Invalid option -a ${DATABASE_DRIVER} with -d ${DBMS}" >&2
+                echo >&2
+                echo "call \"./Build/Scripts/runTests.sh -h\" to display help and valid options" >&2
+                exit 1
+            fi
+            ;;
+    esac
+}
+
+# Load help text into $HELP
+read -r -d '' HELP <<EOF
+dbdoctor test runner. Execute unit test suite and some other details.
+Also used by github for test execution.
+
+Recommended docker version is >=20.10 for xdebug break pointing to work reliably, and
+a recent docker-compose (tested >=1.21.2) is needed.
+
+Usage: $0 [options] [file]
+
+No arguments: Run all unit tests with PHP 7.4
+
+Options:
+    -s <...>
+        Specifies which test suite to run
+            - cgl: cgl test and fix all php files
+            - clean: clean up build and testing related files
+            - composerUpdate: "composer update", handy if host has no PHP
+            - lint: PHP linting
+
+    -p <7.2|7.3|7.4>
+        Specifies the PHP minor version to be used
+            - 7.2 (default): use PHP 7.2
+            - 7.3: use PHP 7.3
+            - 7.4: use PHP 7.4
+
+    -t <10>
+        Only with -s composerUpdate
+        Specifies the TYPO3 core major version to be used
+            - 10 (default): use TYPO3 core v10
+
+    -n
+        Only with -s cgl
+        Activate dry-run in CGL check that does not actively change files and only prints broken ones.
+
+    -u
+        Update existing typo3/core-testing-*:latest docker images. Maintenance call to docker pull latest
+        versions of the main php images. The images are updated once in a while and only the youngest
+        ones are supported by core testing. Use this if weird test errors occur. Also removes obsolete
+        image versions of typo3/core-testing-*.
+
+    -v
+        Enable verbose script output. Shows variables and docker commands.
+
+    -h
+        Show this help.
+
+Examples:
+    # Run unit tests using PHP 7.2
+    ./Build/Scripts/runTests.sh -s unit
+EOF
+
+# Test if docker-compose exists, else exit out with error
+if ! type "docker-compose" > /dev/null; then
+  echo "This script relies on docker and docker-compose. Please install" >&2
+  exit 1
+fi
+
+# Go to the directory this script is located, so everything else is relative
+# to this dir, no matter from where this script is called.
+THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+cd "$THIS_SCRIPT_DIR" || exit 1
+
+# Go to directory that contains the local docker-compose.yml file
+cd ../testing-docker || exit 1
+
+# Option defaults
+if ! command -v realpath &> /dev/null; then
+  echo "This script works best with realpath installed" >&2
+  ROOT_DIR="${PWD}/../../"
+else
+  ROOT_DIR=`realpath ${PWD}/../../`
+fi
+TEST_SUITE=""
+DBMS="sqlite"
+PHP_VERSION="7.2"
+TYPO3_VERSION="10"
+PHP_XDEBUG_ON=0
+EXTRA_TEST_OPTIONS=""
+SCRIPT_VERBOSE=0
+CGLCHECK_DRY_RUN=""
+DATABASE_DRIVER=""
+
+# Option parsing
+# Reset in case getopts has been used previously in the shell
+OPTIND=1
+# Array for invalid options
+INVALID_OPTIONS=();
+# Simple option parsing based on getopts (! not getopt)
+while getopts ":s:a:d:p:t:e:xnhuv" OPT; do
+    case ${OPT} in
+        s)
+            TEST_SUITE=${OPTARG}
+            ;;
+        p)
+            PHP_VERSION=${OPTARG}
+            if ! [[ ${PHP_VERSION} =~ ^(7.4|8.0|8.1|8.2)$ ]]; then
+                INVALID_OPTIONS+=("p ${OPTARG}")
+            fi
+            ;;
+        t)
+            TYPO3_VERSION=${OPTARG}
+            if ! [[ ${TYPO3_VERSION} =~ ^(11|12)$ ]]; then
+                INVALID_OPTIONS+=("p ${OPTARG}")
+            fi
+            ;;
+        h)
+            echo "${HELP}"
+            exit 0
+            ;;
+        n)
+            CGLCHECK_DRY_RUN="-n"
+            ;;
+        u)
+            TEST_SUITE=update
+            ;;
+        v)
+            SCRIPT_VERBOSE=1
+            ;;
+        \?)
+            INVALID_OPTIONS+=(${OPTARG})
+            ;;
+        :)
+            INVALID_OPTIONS+=(${OPTARG})
+            ;;
+    esac
+done
+
+# Exit on invalid options
+if [ ${#INVALID_OPTIONS[@]} -ne 0 ]; then
+    echo "Invalid option(s):" >&2
+    for I in "${INVALID_OPTIONS[@]}"; do
+        echo "-"${I} >&2
+    done
+    echo >&2
+    echo "${HELP}" >&2
+    exit 1
+fi
+
+# Move "7.2" to "php72", the latter is the docker container name
+DOCKER_PHP_IMAGE=`echo "php${PHP_VERSION}" | sed -e 's/\.//'`
+
+# Set $1 to first mass argument, this is the optional test file or test directory to execute
+shift $((OPTIND - 1))
+TEST_FILE=${1}
+if [ -n "${1}" ]; then
+    TEST_FILE="Web/typo3conf/ext/sbuerk_ensureadmin/${1}"
+fi
+
+if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+    set -x
+fi
+
+if [ -z ${TEST_SUITE} ]; then
+    echo "${HELP}"
+    exit 0
+fi
+
+# Suite execution
+case ${TEST_SUITE} in
+    cgl)
+        # Active dry-run for cgl needs not "-n" but specific options
+        if [[ ! -z ${CGLCHECK_DRY_RUN} ]]; then
+            CGLCHECK_DRY_RUN="--dry-run --diff"
+        fi
+        setUpDockerComposeDotEnv
+        docker-compose run cgl
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    clean)
+        rm -rf ../../composer.lock ../../.Build/ ../../Tests/Acceptance/Support/_generated/ ../../composer.json.testing
+        ;;
+    composerUpdate)
+        setUpDockerComposeDotEnv
+        cp ../../composer.json ../../composer.json.orig
+        if [ -f "../../composer.json.testing" ]; then
+            cp ../../composer.json ../../composer.json.orig
+        fi
+        docker-compose run composer_update
+        cp ../../composer.json ../../composer.json.testing
+        mv ../../composer.json.orig ../../composer.json
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    lint)
+        setUpDockerComposeDotEnv
+        docker-compose run lint
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    update)
+        # pull typo3/core-testing-*:latest versions of those ones that exist locally
+        docker images typo3/core-testing-*:latest --format "{{.Repository}}:latest" | xargs -I {} docker pull {}
+        # remove "dangling" typo3/core-testing-* images (those tagged as <none>)
+        docker images typo3/core-testing-* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} docker rmi {}
+        ;;
+    *)
+        echo "Invalid -s option argument ${TEST_SUITE}" >&2
+        echo >&2
+        echo "${HELP}" >&2
+        exit 1
+esac
+
+exit $SUITE_EXIT_CODE

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -58,7 +58,7 @@ handleDbmsAndDriverOptions() {
 
 # Load help text into $HELP
 read -r -d '' HELP <<EOF
-dbdoctor test runner. Execute unit test suite and some other details.
+sbuerk/typo3-ensure-admin test runner. Execute unit test suite and some other details.
 Also used by github for test execution.
 
 Recommended docker version is >=20.10 for xdebug break pointing to work reliably, and
@@ -154,13 +154,13 @@ while getopts ":s:a:d:p:t:e:xnhuv" OPT; do
             ;;
         p)
             PHP_VERSION=${OPTARG}
-            if ! [[ ${PHP_VERSION} =~ ^(7.4|8.0|8.1|8.2)$ ]]; then
+            if ! [[ ${PHP_VERSION} =~ ^(7.2|7.3|7.4)$ ]]; then
                 INVALID_OPTIONS+=("p ${OPTARG}")
             fi
             ;;
         t)
             TYPO3_VERSION=${OPTARG}
-            if ! [[ ${TYPO3_VERSION} =~ ^(11|12)$ ]]; then
+            if ! [[ ${TYPO3_VERSION} =~ ^(10)$ ]]; then
                 INVALID_OPTIONS+=("p ${OPTARG}")
             fi
             ;;

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -75,6 +75,8 @@ Options:
             - clean: clean up build and testing related files
             - composerUpdate: "composer update", handy if host has no PHP
             - lint: PHP linting
+            - phpstan: phpstan analyze
+            - phpstanGenerateBaseline: regenerate phpstan baseline, handy after phpstan updates
 
     -p <7.2|7.3|7.4>
         Specifies the PHP minor version to be used
@@ -244,6 +246,18 @@ case ${TEST_SUITE} in
     lint)
         setUpDockerComposeDotEnv
         docker-compose run lint
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    phpstan)
+        setUpDockerComposeDotEnv
+        docker-compose run phpstan
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    phpstanGenerateBaseline)
+        setUpDockerComposeDotEnv
+        docker-compose run phpstan_generate_baseline
         SUITE_EXIT_CODE=$?
         docker-compose down
         ;;

--- a/Build/php-cs-fixer/php-cs-fixer.php
+++ b/Build/php-cs-fixer/php-cs-fixer.php
@@ -1,0 +1,11 @@
+<?php
+
+$config = \TYPO3\CodingStandards\CsFixerConfig::create();
+$config->setHeader('This file is part of the `sbuerk/typo3-ensure-admin` extension.');
+$config->setFinder(
+    (new PhpCsFixer\Finder())
+        ->ignoreVCSIgnored(true)
+        ->notPath('/^Build\/php-cs-fixer\/php-cs-fixer.php/')
+        ->notName('/^ext_emconf.php/')
+);
+return $config;

--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1,0 +1,2 @@
+parameters:
+	ignoreErrors:

--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -1,0 +1,18 @@
+includes:
+  - ../../.Build/vendor/phpstan/phpstan-strict-rules/rules.neon
+  - ../../.Build/vendor/phpstan/phpstan-phpunit/extension.neon
+  - phpstan-baseline.neon
+
+parameters:
+  # Use local .cache dir instead of /tmp
+  tmpDir: ../../.cache/phpstan
+
+  level: max
+
+  paths:
+    - ../../Classes/
+    - ../../Tests/
+
+  strictRules:
+    # @todo Recheck disabled useless cast rule from time to time, if reportings are still unsafe to remove.
+    # uselessCast: false

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -1,0 +1,71 @@
+version: '2.3'
+services:
+  cgl:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          php -dxdebug.mode=off \
+            .Build/bin/php-cs-fixer fix \
+              -v \
+              ${CGLCHECK_DRY_RUN} \
+              --config=Build/php-cs-fixer/php-cs-fixer.php \
+              --using-cache=no .
+        else
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_host=host.docker.internal\" \
+          PHP_CS_FIXER_ALLOW_XDEBUG=1 \
+          .Build/bin/php-cs-fixer fix \
+            -v \
+            ${CGLCHECK_DRY_RUN} \
+            --config=Build/php-cs-fixer/php-cs-fixer.php \
+            --using-cache=no .
+        fi
+      "
+
+  composer_update:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        if [ ${TYPO3_VERSION} -eq 10 ]; then
+              composer req --dev typo3/cms-backend:^10.4 --no-update
+              composer req typo3/cms-core:^10.4 --no-update
+        fi
+        composer update --no-progress --no-interaction;
+      "
+
+  lint:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        find . -name \\*.php ! -path "./.Build/\\*" -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null
+      "

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -69,3 +69,34 @@ services:
         php -v | grep '^PHP';
         find . -name \\*.php ! -path "./.Build/\\*" -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null
       "
+
+  phpstan:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        mkdir -p .Build/.cache
+        php -v | grep '^PHP';
+        php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan/phpstan.neon --no-progress
+      "
+  phpstan_generate_baseline:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        mkdir -p .Build/.cache
+        php -v | grep '^PHP';
+        php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan/phpstan.neon --generate-baseline=Build/phpstan/phpstan-baseline.neon
+      "

--- a/Classes/Commands/AdminEnsureCommand.php
+++ b/Classes/Commands/AdminEnsureCommand.php
@@ -2,9 +2,21 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the `sbuerk/typo3-ensure-admin` extension.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace SBUERK\EnsureAdmin\Commands;
 
 class AdminEnsureCommand
 {
-
 }

--- a/Classes/Commands/AdminEnsureCommand.php
+++ b/Classes/Commands/AdminEnsureCommand.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SBUERK\EnsureAdmin\Commands;
+
+class AdminEnsureCommand
+{
+
+}

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "typo3/cms-core": "^10.4"
     },
     "require-dev": {
-        "typo3/cms-composer-installers": "^3.0"
+        "typo3/cms-composer-installers": "^3.0",
+        "typo3/coding-standards": "^0.5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "typo3/cms": {
             "app-dir": ".Build",
             "web-dir": ".Build/Web",
-            "extension-key": "ensureadmin"
+            "extension-key": "sbuerk_ensureadmin"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
         "typo3/cms-core": "^10.4"
     },
     "require-dev": {
+        "phpstan/phpstan": "^1.8.4",
+        "phpstan/phpstan-phpunit": "^1.1.1",
+        "phpstan/phpstan-strict-rules": "^1.4.3",
         "typo3/cms-backend": "^10.4",
         "typo3/cms-composer-installers": "^3.0",
         "typo3/coding-standards": "^0.5.0"

--- a/composer.json
+++ b/composer.json
@@ -1,50 +1,63 @@
 {
-	"name": "sbuerk/typo3-ensure-admin",
-	"description": "Provides a TYPO3 cli command to create or update admin user",
-	"type": "typo3-cms-extension",
-	"license": "GPL-2.0-or-later",
-	"authors": [
-		{
-			"name": "Stefan Bürk",
-			"email": "stefan@buerk.tech",
-			"role": "Maintainer"
-		}
-	],
-	"config": {
-		"allow-plugins": {
-			"typo3/cms-composer-installers": true,
-			"typo3/class-alias-loader": true
-		},
-		"sort-packages": true,
-		"vendor-dir": ".Build/vendor",
-		"bin-dir": ".Build/bin"
-	},
-	"require": {
-		"php": "^7.2 || ^7.3 || ^7.4",
-		"typo3/cms-core": "^10.4"
-	},
-	"require-dev": {
-		"typo3/cms-composer-installers": "^3.0",
-		"typo3/coding-standards": "^0.5.0"
-	},
-	"autoload": {
-		"psr-4": {
-			"SBUERK\\EnsureAdmin\\": "Classes/"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"SBUERK\\EnsureAdmin\\Tests\\": "Tests/"
-		}
-	},
-	"extra": {
-		"branch-alias": {
-			"dev-main": "0.x-dev"
-		},
-		"typo3/cms": {
-			"app-dir": ".Build",
-			"web-dir": ".Build/Web",
-			"extension-key": "sbuerk_ensureadmin"
-		}
-	}
+    "name": "sbuerk/typo3-ensure-admin",
+    "description": "Provides a TYPO3 cli command to create or update admin user",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Stefan Bürk",
+            "email": "stefan@buerk.tech",
+            "role": "Maintainer"
+        }
+    ],
+    "config": {
+        "allow-plugins": {
+            "typo3/cms-composer-installers": true,
+            "typo3/class-alias-loader": true
+        },
+        "sort-packages": true,
+        "vendor-dir": ".Build/vendor",
+        "bin-dir": ".Build/bin"
+    },
+    "require": {
+        "php": "^7.2 || ^7.3 || ^7.4",
+        "typo3/cms-core": "^10.4"
+    },
+    "require-dev": {
+        "typo3/cms-backend": "^10.4",
+        "typo3/cms-composer-installers": "^3.0",
+        "typo3/coding-standards": "^0.5.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "SBUERK\\EnsureAdmin\\": "Classes/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "SBUERK\\EnsureAdmin\\Tests\\": "Tests/"
+        }
+    },
+    "scripts": {
+        "cgl:check": [
+            "@php -dxdebug.mode=off .Build/bin/php-cs-fixer fix --config=.Build/vendor/typo3/coding-standards/templates/extension_php-cs-fixer.dist.php --dry-run --diff --using-cache=no"
+        ],
+        "cgl:fix": [
+            "@php -dxdebug.mode=off .Build/bin/php-cs-fixer fix --config=.Build/vendor/typo3/coding-standards/templates/extension_php-cs-fixer.dist.php --using-cache=no"
+        ]
+    },
+    "scripts-descriptions": {
+        "cgl:check": "Checks all php source files for coding standard compliance.",
+        "cgl:fix": "Checks all php source files for coding standard compliance and fixes them."
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
+        "typo3/cms": {
+            "app-dir": ".Build",
+            "web-dir": ".Build/Web",
+            "extension-key": "sbuerk_ensureadmin"
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "bin-dir": ".Build/bin"
     },
     "require": {
-        "php": "^7.2 || ^7.3 || ^7.4"
+        "php": "^7.2 || ^7.3 || ^7.4",
+        "typo3/cms-core": "^10.4"
     },
     "require-dev": {
         "typo3/cms-composer-installers": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -1,50 +1,50 @@
 {
-    "name": "sbuerk/typo3-ensure-admin",
-    "description": "Provides a TYPO3 cli command to create or update admin user",
-    "type": "typo3-cms-extension",
-    "license": "GPL-2.0-or-later",
-    "authors": [
-        {
-            "name": "Stefan Bürk",
-            "email": "stefan@buerk.tech",
-            "role": "Maintainer"
-        }
-    ],
-    "config": {
-        "allow-plugins": {
-            "typo3/cms-composer-installers": true,
-            "typo3/class-alias-loader": true
-        },
-        "sort-packages": true,
-        "vendor-dir": ".Build/vendor",
-        "bin-dir": ".Build/bin"
-    },
-    "require": {
-        "php": "^7.2 || ^7.3 || ^7.4",
-        "typo3/cms-core": "^10.4"
-    },
-    "require-dev": {
-        "typo3/cms-composer-installers": "^3.0",
-        "typo3/coding-standards": "^0.5.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "SBUERK\\EnsureAdmin\\": "Classes/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "SBUERK\\EnsureAdmin\\Tests\\": "Tests/"
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-main": "0.x-dev"
-        },
-        "typo3/cms": {
-            "app-dir": ".Build",
-            "web-dir": ".Build/Web",
-            "extension-key": "sbuerk_ensureadmin"
-        }
-    }
+	"name": "sbuerk/typo3-ensure-admin",
+	"description": "Provides a TYPO3 cli command to create or update admin user",
+	"type": "typo3-cms-extension",
+	"license": "GPL-2.0-or-later",
+	"authors": [
+		{
+			"name": "Stefan Bürk",
+			"email": "stefan@buerk.tech",
+			"role": "Maintainer"
+		}
+	],
+	"config": {
+		"allow-plugins": {
+			"typo3/cms-composer-installers": true,
+			"typo3/class-alias-loader": true
+		},
+		"sort-packages": true,
+		"vendor-dir": ".Build/vendor",
+		"bin-dir": ".Build/bin"
+	},
+	"require": {
+		"php": "^7.2 || ^7.3 || ^7.4",
+		"typo3/cms-core": "^10.4"
+	},
+	"require-dev": {
+		"typo3/cms-composer-installers": "^3.0",
+		"typo3/coding-standards": "^0.5.0"
+	},
+	"autoload": {
+		"psr-4": {
+			"SBUERK\\EnsureAdmin\\": "Classes/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"SBUERK\\EnsureAdmin\\Tests\\": "Tests/"
+		}
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-main": "0.x-dev"
+		},
+		"typo3/cms": {
+			"app-dir": ".Build",
+			"web-dir": ".Build/Web",
+			"extension-key": "sbuerk_ensureadmin"
+		}
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
     "require": {
         "php": "^7.2 || ^7.3 || ^7.4"
     },
-    "require-dev": {},
+    "require-dev": {
+        "typo3/cms-composer-installers": "^3.0"
+    },
     "autoload": {
         "psr-4": {
             "SBUERK\\EnsureAdmin\\": "Classes/"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,0 +1,22 @@
+<?php
+
+$EM_CONF['sbuerk_ensureadmin'] = [
+    'title' => 'TYPO3 Ensure Admin User',
+    'description' => 'Provides a TYPO3 cli command to create or update admin user',
+    'category' => 'misc',
+    'version' => '0.0.0',
+    'module' => '',
+    'state' => 'stable',
+    'clearCacheOnLoad' => 1,
+    'author' => 'Stefan Bürk',
+    'author_email' => 'stefan@buerk.tech',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '10.4.0-10.99.99',
+        ],
+        'conflicts' => [
+        ],
+        'suggests' => [
+        ],
+    ],
+];


### PR DESCRIPTION
- [TASK] Require dev dependency `typo3/cms-composer-installers`
- [TASK] Prefix TYPO3 Extension Key to avoid conflicts
- [TASK] Require `typo3/cms-core:^10.4` as dependency
- [TASK] Provide extension `em_extconf.php`
- [TASK] Add typo3/coding-standards as dependency
- [TASK] Provide .editorconfig from coding-standards with adjustments
- [TASK] Add AdminEnsureCommand class skeleton without function
- [TASK] Add Build/Scripts/runTests.sh for TYPO3v10 and first minimum suits
- [TASK] Introduce phpstan as static code analyzer
- [TASK] Add first github action workflows
