### PR TITLE
[TASK] Streamline publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,43 +1,87 @@
 name: publish
 on:
   push:
-    tag:
+    tags:
+      - '*'
+
 jobs:
   publish:
-    name: Publish new version to TER
+    name: Ensure GitHub Release with extension TER artifact and publishing to TER
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
+      TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
       TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Check tag
+      - name: Verify tag
         run: |
           if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
+            echo "ERR: Invalid publish version tag: ${{ github.ref }}"
             exit 1
           fi
 
       - name: Get version
         id: get-version
-        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
       - name: Get comment
         id: get-comment
         run: |
-          readonly local comment=$(git tag -n10 -l ${{ steps.get-version.outputs.version }} | sed "s/^[0-9.]*[ ]*//g")
-          echo "comment=$comment" >> $GITHUB_OUTPUT
+          readonly local releaseCommentPrependBody="$( git tag -l ${{ env.version }} --format '%(contents)' )"
+          if (( $(grep -c . <<<"${releaseCommentPrependBody// }") > 1 )); then
+            {
+              echo 'releaseCommentPrependBody<<EOF'
+              echo "$releaseCommentPrependBody"
+              echo EOF
+            } >> "$GITHUB_ENV"
+          fi
+          {
+            echo 'terReleaseNotes<<EOF'
+            echo "https://github.com/fgtclb/academic-persons/releases/tag/${{ env.version }}"
+            echo EOF
+          } >> "$GITHUB_ENV"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.0
           extensions: intl, mbstring, json, zip, curl
           tools: composer:v2
 
       - name: Install tailor
         run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
 
+      # Note that step will fail when `env.version` does not match the `ext_emconf.php` version.
+      - name: Create local TER package upload artifact
+        run: |
+          php ~/.composer/vendor/bin/tailor create-artefact ${{ env.version }}
+
+      # Note that when release already exists for tag, only files will be uploaded and lets this acting as a
+      # fallback to ensure that a real GitHub release is created for the tag along with extension artifacts.
+      - name: Create release and upload artifacts in the same step
+        uses: softprops/action-gh-release@v2
+        if: ${{startsWith(github.ref, 'refs/tags/') }}
+        with:
+          name: "[RELEASE] ${{ env.version }}"
+          body: "${{ env.releaseCommentPrependBody }}"
+          generate_release_notes: true
+          files: |
+            tailor-version-artefact/${{ env.TYPO3_EXTENSION_KEY }}_${{ env.version }}.zip
+            LICENSE
+          fail_on_unmatched_files: true
+
+      # @todo Currently an issue exists with the TYPO3 Extension Repository (TER) tailor based uploads, which seems to
+      #       be WAF related and the T3O TER Team working on. Allow this step to fail (continue on error) for now until
+      #       issues has been sorted out.
+      #       https://github.com/TYPO3/tailor/issues/82
       - name: Publish to TER
-        run: php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ steps.get-comment.outputs.comment }}" ${{ steps.get-version.outputs.version }}
+        # @todo Remove `continue-on-error` after upload with tailor has been fixed.
+        continue-on-error: true
+        run: |
+          php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ env.terReleaseNotes }}" ${{ env.version }} \
+            --artefact=tailor-version-artefact/${{ env.TYPO3_EXTENSION_KEY }}_${{ env.version }}.zip

--- a/.github/workflows/testcore11.yml
+++ b/.github/workflows/testcore11.yml
@@ -18,7 +18,14 @@ jobs:
         php: [ '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: "Link docker compose"
+        run: |
+          echo "#!/usr/bin/env bash" > /usr/local/bin/docker-compose
+          echo "" >> /usr/local/bin/docker-compose
+          echo "docker compose \"\$@\"" >> /usr/local/bin/docker-compose
+          chmod a+x /usr/local/bin/docker-compose
 
       - name: Install testing system
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t 11 -s composerUpdate

--- a/.github/workflows/testcore12.yml
+++ b/.github/workflows/testcore12.yml
@@ -18,7 +18,14 @@ jobs:
         php: [ '8.1', '8.2']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: "Link docker compose"
+        run: |
+          echo "#!/usr/bin/env bash" > /usr/local/bin/docker-compose
+          echo "" >> /usr/local/bin/docker-compose
+          echo "docker compose \"\$@\"" >> /usr/local/bin/docker-compose
+          chmod a+x /usr/local/bin/docker-compose
 
       - name: Install testing system
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t 12 -s composerUpdate

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,10 @@
 .cache/
 .idea/
 /var/
-Build/testing-docker/.env
-composer.json.testing
-composer.lock
+/Build/testing-docker/.env
+/composer.json.testing
+/composer.json.orig
+/composer.lock
 
-README.pdf
-README.html
+/README.pdf
+/README.html


### PR DESCRIPTION
This change updates the `publish` GitHub
worflow for releases to a more modern
version.

Currently, `tailor` will be used from a
branch to test it the automatic upload
to the TYPO3 Extension Registry works,
which is currently broken.
